### PR TITLE
Архивация задач: привязка к сущностям

### DIFF
--- a/migrations/m240520_000001_create_req3_task_archive_table.php
+++ b/migrations/m240520_000001_create_req3_task_archive_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use yii\db\Migration;
+
+class m240520_000001_create_req3_task_archive_table extends Migration
+{
+    public $db = 'db_req3_archive';
+
+    public function safeUp()
+    {
+        $this->createTable('{{%req3_task_archive}}', [
+            // первичный ключ совпадает с ID задачи
+            'task_id' => $this->primaryKey(),
+            'task_name' => $this->string()->notNull(),
+            'template_id' => $this->integer()->notNull(),
+            'template_name' => $this->string()->notNull(),
+            'task_date_create' => $this->dateTime()->notNull(),
+            'task_date_start_step' => $this->dateTime()->notNull(),
+            'date_add_to_archive' => $this->dateTime()->notNull(),
+            'step_is_last' => $this->tinyInteger(),
+            'step_last_status' => $this->integer(),
+            'data_json' => $this->text(),
+        ]);
+    }
+
+    public function safeDown()
+    {
+        $this->dropTable('{{%req3_task_archive}}');
+    }
+}

--- a/migrations/m240520_000002_create_req3_task_archive_entity_table.php
+++ b/migrations/m240520_000002_create_req3_task_archive_entity_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use yii\db\Migration;
+
+class m240520_000002_create_req3_task_archive_entity_table extends Migration
+{
+    public $db = 'db_req3_archive';
+
+    public function safeUp()
+    {
+        $this->createTable('{{%req3_task_archive_entity}}', [
+            'id' => $this->primaryKey(),
+            'task_id' => $this->integer()->notNull(),
+            'value_id' => $this->integer()->notNull(),
+            'identifier_type' => $this->integer()->notNull(),
+        ]);
+
+        $this->createIndex(
+            'uq_req3_task_archive_entity',
+            '{{%req3_task_archive_entity}}',
+            ['task_id', 'value_id', 'identifier_type'],
+            true
+        );
+    }
+
+    public function safeDown()
+    {
+        $this->dropTable('{{%req3_task_archive_entity}}');
+    }
+}

--- a/modules/process/models/task_archive/TaskArchive.php
+++ b/modules/process/models/task_archive/TaskArchive.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace app\modules\process\models\task_archive;
+
+use Yii;
+use yii\db\ActiveRecord;
+use app\modules\process\models\task_archive\TaskArchiveEntity;
+
+/**
+ * Модель архива задач.
+ *
+ * @property int         $task_id          ID задачи (первичный ключ)
+ * @property string      $task_name        Название задачи
+ * @property int         $template_id      ID шаблона
+ * @property string      $template_name    Название шаблона
+ * @property string      $task_date_create Дата создания задачи
+ * @property string      $task_date_start_step Дата начала шага
+ * @property string      $date_add_to_archive Дата добавления в архив
+ * @property int|null    $step_is_last     Признак последнего шага
+ * @property int|null    $step_last_status Финальный статус шага
+ * @property string|null $data_json        Дополнительные данные
+ */
+class TaskArchive extends ActiveRecord
+{
+    /**
+     * Используем отдельное подключение к БД архива.
+     */
+    public static function getDb()
+    {
+        return Yii::$app->get('db_req3_archive');
+    }
+
+    public static function tableName(): string
+    {
+        return '{{%req3_task_archive}}';
+    }
+
+    /**
+     * Первичный ключ таблицы.
+     */
+    public static function primaryKey(): array
+    {
+        return ['task_id'];
+    }
+
+    /**
+     * Правила валидации.
+     */
+    public function rules(): array
+    {
+        return [
+            [['task_id', 'task_name', 'template_id', 'template_name', 'task_date_create', 'task_date_start_step', 'date_add_to_archive'], 'required'],
+            [['task_id', 'template_id', 'step_is_last', 'step_last_status'], 'integer'],
+            [['task_date_create', 'task_date_start_step', 'date_add_to_archive', 'data_json'], 'safe'],
+            [['task_name', 'template_name'], 'string', 'max' => 255],
+        ];
+    }
+
+    /**
+     * Связанные сущности архива.
+     */
+    public function getEntities()
+    {
+        return $this->hasMany(TaskArchiveEntity::class, ['task_id' => 'task_id']);
+    }
+}

--- a/modules/process/models/task_archive/TaskArchiveEntity.php
+++ b/modules/process/models/task_archive/TaskArchiveEntity.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace app\modules\process\models\task_archive;
+
+use Yii;
+use yii\db\ActiveRecord;
+
+/**
+ * Связь архивной задачи с сущностями.
+ *
+ * @property int $id               Первичный ключ
+ * @property int $task_id          ID задачи из архива
+ * @property int $value_id         ID связанной сущности
+ * @property int $identifier_type  Тип идентификатора сущности
+ */
+class TaskArchiveEntity extends ActiveRecord
+{
+    /**
+     * Используем подключение к БД архива.
+     */
+    public static function getDb()
+    {
+        return Yii::$app->get('db_req3_archive');
+    }
+
+    public static function tableName(): string
+    {
+        return '{{%req3_task_archive_entity}}';
+    }
+
+    public static function primaryKey(): array
+    {
+        return ['id'];
+    }
+
+    public function rules(): array
+    {
+        return [
+            [['task_id', 'value_id', 'identifier_type'], 'required'],
+            [['task_id', 'value_id', 'identifier_type'], 'integer'],
+        ];
+    }
+}

--- a/modules/process/services/ProcessTaskService.php
+++ b/modules/process/services/ProcessTaskService.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace app\modules\process\services;
+
+use app\modules\process\models\task\Req3Tasks;
+use app\modules\process\models\task\Req3TemplateSteps;
+use app\modules\process\models\task_archive\TaskArchive;
+use app\modules\process\models\task_archive\TaskArchiveEntity;
+use yii\db\Expression;
+use Yii;
+
+/**
+ * Сервис для архивации завершённых задач.
+ */
+class ProcessTaskService
+{
+    /**
+     * Находит задачи, которые требуется архивировать согласно параметру delete_after_days.
+     *
+     * @return Req3Tasks[]
+     */
+    public function findTasksForArchive(): array
+    {
+        $today = new \DateTimeImmutable('today');
+
+        $steps = Req3TemplateSteps::find()
+            ->select(['id', 'delete_after_days'])
+            ->where(['not', ['delete_after_days' => null]])
+            ->asArray()
+            ->all();
+
+        if (empty($steps)) {
+            return [];
+        }
+
+        $condition = ['or'];
+        foreach ($steps as $step) {
+            $threshold = $today->modify('-' . $step['delete_after_days'] . ' days')->format('Y-m-d');
+            $condition[] = ['and',
+                ['req3_tasks.step_id' => $step['id']],
+                ['<=', 'req3_tasks.date_start_step', $threshold],
+            ];
+        }
+
+        if (count($condition) === 1) {
+            return [];
+        }
+
+        return Req3Tasks::find()
+            ->where(['not', ['req3_tasks.date_start_step' => null]])
+            ->andWhere($condition)
+            ->joinWith(['step.template', 'step.version'])
+            ->all();
+    }
+
+    /**
+     * Архивирует задачу и удаляет её из основной таблицы.
+     */
+    public function archiveTask(Req3Tasks $task): bool
+    {
+        $version = $task->step->version;
+        $archiveIdentifiers = $version->setting['archiveIdentifiers'] ?? [];
+
+        // собираем уникальные данные по идентификаторам, чтобы избежать дубликатов
+        $dataItems = [];
+        $unique = [];
+        foreach ($archiveIdentifiers as $identifierId) {
+            $items = $task->getDataIdentifier($identifierId, true, true);
+            foreach ($items as $item) {
+                $key = $item->value_id . ':' . $item->type;
+                if (!isset($unique[$key])) {
+                    $unique[$key] = true;
+                    $dataItems[] = $item;
+                }
+            }
+        }
+
+        if (empty($dataItems)) {
+            Yii::warning("Задача {$task->id} не содержит данных для архивирования", __METHOD__);
+            return false;
+        }
+
+        $db = TaskArchive::getDb();
+        $transaction = $db->beginTransaction();
+        try {
+            $archive = new TaskArchive();
+            $archive->task_id = $task->id;
+            $archive->task_name = $task->name;
+            $archive->template_id = $task->template_id;
+            $archive->template_name = $task->step->template->name ?? '';
+            $archive->task_date_create = $task->create_date;
+            $archive->task_date_start_step = $task->date_start_step;
+            $archive->date_add_to_archive = new Expression('NOW()');
+            $archive->step_is_last = (int)$task->step->is_last;
+            $archive->step_last_status = $task->step->last_status;
+            $archive->data_json = json_encode($this->collectTaskData($task));
+
+            if (!$archive->save()) {
+                $transaction->rollBack();
+                return false;
+            }
+
+            foreach ($dataItems as $item) {
+                $link = new TaskArchiveEntity();
+                $link->task_id = $task->id;
+                $link->value_id = $item->value_id;
+                $link->identifier_type = $item->type;
+                if (!$link->save()) {
+                    $transaction->rollBack();
+                    return false;
+                }
+            }
+
+            $transaction->commit();
+        } catch (\Throwable $e) {
+            $transaction->rollBack();
+            Yii::error("Ошибка архивации задачи {$task->id}: {$e->getMessage()}", __METHOD__);
+            return false;
+        }
+
+        return (bool)$task->delete();
+    }
+
+    /**
+     * Заглушка для сбора дополнительных данных задачи для архива.
+     */
+    protected function collectTaskData(Req3Tasks $task): array
+    {
+        return [];
+    }
+
+    /**
+     * Архивирует все доступные задачи.
+     */
+    public function archiveAvailableTasks(): void
+    {
+        foreach ($this->findTasksForArchive() as $task) {
+            $this->archiveTask($task);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Применена транзакция при сохранении архивной записи и связанных сущностей
- Исключены дубликаты данных идентификаторов перед переносом в таблицу связей
- Используется подключение db_req3_archive для модели и миграций
- Файлы сервиса и моделей перенесены из `app/modules` в корневой `modules`

## Testing
- `php -l modules/process/services/ProcessTaskService.php`
- `php -l modules/process/models/task_archive/TaskArchive.php`
- `php -l modules/process/models/task_archive/TaskArchiveEntity.php`
- `php -l migrations/m240520_000001_create_req3_task_archive_table.php`
- `php -l migrations/m240520_000002_create_req3_task_archive_entity_table.php`
- `composer test` *(fails: Command "test" is not defined.)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a61372d67883218a01f5d5fea483e2