### PR TITLE
Add task archive browsing

### DIFF
--- a/modules/process/controllers/TaskArchiveController.php
+++ b/modules/process/controllers/TaskArchiveController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace app\modules\process\controllers;
+
+use app\modules\process\models\task_archive\TaskArchive;
+use app\modules\process\models\FormReq3SearchArchive;
+use yii\web\Controller;
+use yii\web\NotFoundHttpException;
+use Yii;
+
+class TaskArchiveController extends Controller
+{
+    public function actionIndex()
+    {
+        $searchModel = new FormReq3SearchArchive();
+        $dataProvider = $searchModel->search(Yii::$app->request->queryParams);
+
+        return $this->render('index', [
+            'searchModel' => $searchModel,
+            'dataProvider' => $dataProvider,
+        ]);
+    }
+
+    public function actionView($id)
+    {
+        $model = TaskArchive::find()->andWhere(['task_id' => $id])->one();
+        if (!$model) {
+            throw new NotFoundHttpException('Архивная задача не найдена.');
+        }
+
+        $items = [];
+        if (!empty($model->data_json)) {
+            $items = json_decode($model->data_json, true) ?: [];
+        }
+
+        return $this->render('history', [
+            'task' => $model,
+            'items' => $items,
+        ]);
+    }
+}

--- a/modules/process/models/FormReq3SearchArchive.php
+++ b/modules/process/models/FormReq3SearchArchive.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace app\modules\process\models;
+
+use yii\base\Model;
+use yii\data\ActiveDataProvider;
+use app\modules\process\models\task_archive\TaskArchive;
+
+class FormReq3SearchArchive extends Model
+{
+    public $template_id;
+    public $template_name;
+    public $dateRange;
+
+    public function rules(): array
+    {
+        return [
+            [['template_id'], 'integer'],
+            [['template_name', 'dateRange'], 'safe'],
+            [['dateRange'], 'required'],
+            ['dateRange', 'validateDateRange'],
+        ];
+    }
+
+    public function validateDateRange($attribute)
+    {
+        $arr = explode(' - ', (string)$this->dateRange);
+        if (count($arr) !== 2) {
+            $this->addError($attribute, 'Неверный диапазон дат.');
+            return;
+        }
+        [$from, $to] = $arr;
+        if (strtotime($from) === false || strtotime($to) === false || strtotime($from) > strtotime($to)) {
+            $this->addError($attribute, 'Начальная дата больше конечной.');
+        }
+    }
+
+    public function search(array $params): ActiveDataProvider
+    {
+        $query = TaskArchive::find();
+
+        $this->load($params);
+        if (!$this->validate()) {
+            $query->where('0=1');
+        } else {
+            if ($this->template_id) {
+                $query->andWhere(['template_id' => $this->template_id]);
+            }
+            if ($this->template_name) {
+                $query->andFilterWhere(['like', 'template_name', $this->template_name]);
+            }
+            if ($this->dateRange) {
+                [$from, $to] = explode(' - ', $this->dateRange);
+                $query->andWhere(['between', 'task_date_create', $from, $to]);
+            }
+        }
+
+        return new ActiveDataProvider([
+            'query' => $query,
+            'sort' => [
+                'defaultOrder' => ['task_id' => SORT_DESC],
+            ],
+        ]);
+    }
+}

--- a/modules/process/models/task_archive/TaskArchive.php
+++ b/modules/process/models/task_archive/TaskArchive.php
@@ -40,4 +40,9 @@ class TaskArchive extends ActiveRecord
             [['task_name', 'template_name'], 'string', 'max' => 255],
         ];
     }
+
+    public function getId()
+    {
+        return $this->task_id;
+    }
 }

--- a/modules/process/views/task-archive/history.php
+++ b/modules/process/views/task-archive/history.php
@@ -1,0 +1,47 @@
+<?php
+/* @var $this yii\web\View */
+/* @var $task app\modules\process\models\task_archive\TaskArchive */
+/* @var $items array */
+?>
+
+<div data-step-history="1">
+    <div class="timeline">
+        <?php $last_date = null; ?>
+        <?php foreach ($items as $item): ?>
+            <?php $date_check = $item['time']; ?>
+            <?php require 'history/time_label.php'; ?>
+
+            <?php if ($item['type'] === 'info'): ?>
+                <?= $this->render('history/info', ['item' => $item['item']]); ?>
+            <?php endif; ?>
+
+            <?php if ($item['type'] === 'link'): ?>
+                <?= $this->render('history/link', ['item' => $item['item']]); ?>
+            <?php endif; ?>
+
+            <?php if ($item['type'] === 'transition'): ?>
+                <?= $this->render('history/transition_info', ['item' => $item['item']]); ?>
+            <?php endif; ?>
+
+            <?php if ($item['type'] === 'transition_detail'): ?>
+                <?= $this->render('history/transition_detail_info', ['item' => $item['item']]); ?>
+            <?php endif; ?>
+
+            <?php if ($item['type'] === 'rule2_detail'): ?>
+                <?= $this->render('history/transition_rule2_info', ['task' => $task, 'item' => $item['item']]); ?>
+            <?php endif; ?>
+
+            <?php if ($item['type'] === 'step'): ?>
+                <?= $this->render('history/step', ['item' => $item['item'], 'online' => $item['online'] ?? []]); ?>
+            <?php endif; ?>
+
+            <?php if ($item['type'] === 'function'): ?>
+                <?= $this->render('history/function', ['item' => $item['item']]); ?>
+            <?php endif; ?>
+
+            <?php if ($item['type'] === 'data'): ?>
+                <?= $this->render('history/data_changed', ['item' => $item['item'], 'show_id' => null]); ?>
+            <?php endif; ?>
+        <?php endforeach; ?>
+    </div>
+</div>

--- a/modules/process/views/task-archive/history/data_changed.php
+++ b/modules/process/views/task-archive/history/data_changed.php
@@ -1,0 +1,32 @@
+<?php
+
+use app\components\Date;
+use app\modules\process\components\HelperOper;
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+/* @var $item array */
+/* @var $show_id int */
+
+?>
+
+<div style="margin-left: 60px; font-size: small; color: #9b9b9b; <?= $show_id != null ? "display:none;" : "" ?>" data-spoiler-content="<?= $show_id ?>">
+
+    <?php if ($item['time'] ?? false): ?>
+        <div><i class="fas fa-clock"></i> <?= (new Date($item['time']))->format(Date::FORMAT_DATE_TIME) ?>
+
+            <?php if ($item['oper_id'] ?? false): ?>
+                <span style="color: #9985af">(<?= HelperOper::getFioById($item['oper_id']) ?>)</span>
+            <?php endif; ?>
+        </div>
+    <?php endif; ?>
+
+
+    <div style="overflow: hidden; word-break: break-word;"><i class="fas fa-pencil-alt"></i> <b style="color: #6f8ea9;"><?= $item['name'] ?></b>:
+        <?php if (count($item['value'] ?? []) == 0): ?>
+            <i class="fas fa-trash-alt"></i> Очищено
+        <?php else: ?>
+            <?= nl2br(Html::encode(implode(", ", $item['value']))) ?>
+        <?php endif; ?>
+    </div>
+</div>

--- a/modules/process/views/task-archive/history/function.php
+++ b/modules/process/views/task-archive/history/function.php
@@ -1,0 +1,58 @@
+<?php
+
+use app\components\Date;
+use app\modules\process\components\HelperOper;
+use app\modules\process\models\Req3FunctionBase;
+
+/* @var $this yii\web\View */
+/* @var $item array */
+?>
+
+
+<div style="margin-left: 60px; font-size: small; color: #815987;" title="Информация о запущенной Функции">
+
+
+    <?php if (isset($item['name'])): ?>
+        <div>
+            <i class="fas fa-meteor"></i> <?= $item['name'] ?>
+        </div>
+    <?php endif; ?>
+
+    <?php if ($item['type'] == Req3FunctionBase::TYPE_CLICK_BTN): ?>
+        <?php if (isset($item['time_start'])): ?>
+            <div>
+                <i class="fas fa-clock"></i> <?= (new Date($item['time_start']))->format(Date::FORMAT_DATE_TIME) ?>
+                <?php if (isset($item['oper_id'])): ?>
+                    <span style="color: #9985af">(<?= HelperOper::getFioById($item['oper_id']) ?>)</span>
+                <?php endif; ?>
+            </div>
+        <?php endif; ?>
+
+        <?php if (isset($item['btn_name'])): ?>
+            <div>
+                <i class="fas fa-mouse"></i> <?= $item['btn_name'] ?>
+            </div>
+        <?php endif; ?>
+
+    <?php endif; ?>
+
+    <?php if (isset($item['data']) && count($item['data']) > 0): ?>
+        <div>
+            <div><i class="fas fa-database"></i> Данные:</div>
+            <?php foreach ($item['data'] as $error): ?>
+                <div style="margin-left: 20px"><?= $error ?></div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <?php if (isset($item['errors']) && count($item['errors']) > 0): ?>
+        <div style="color: #c54a4a">
+            <div><i class="fas fa-exclamation-circle"></i> Ошибки:</div>
+            <?php foreach ($item['errors'] as $error): ?>
+                <div style="margin-left: 20px"><?= $error ?></div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+
+</div>

--- a/modules/process/views/task-archive/history/info.php
+++ b/modules/process/views/task-archive/history/info.php
@@ -1,0 +1,19 @@
+<?php
+
+use app\components\Date;
+use app\components\Str;
+use app\modules\process\models\task\Req3Tasks;
+
+/* @var $this yii\web\View */
+/* @var $task Req3Tasks */
+/* @var $item array */
+
+$date = new Date($item['time_start']);
+?>
+
+<div style="margin-left: 60px; font-size: small; color: #2343a1" title="Информация">
+    <div>
+        <i class="fas fa-exclamation-triangle"></i> <?= $date->format(Date::FORMAT_DATE_TIME) ?>
+        <span><?= nl2br(Str::toLink($item['message'])) ?></span>
+    </div>
+</div>

--- a/modules/process/views/task-archive/history/link.php
+++ b/modules/process/views/task-archive/history/link.php
@@ -1,0 +1,49 @@
+<?php
+
+use app\components\Date;
+use app\modules\process\components\HelperOper;
+use app\modules\process\models\task\Req3Tasks;
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+/* @var $task Req3Tasks */
+/* @var $item array */
+
+$date = new Date($item['time_start']);
+
+
+?>
+
+<div style="margin-left: 60px; font-size: small; color: #2343a1" title="Информация">
+    <div>
+
+        <?php if ($item['type'] == "link"): ?>
+            <i class="fas fa-link" style="color: #048712"></i>
+            <span style="color: #048712">(<?= HelperOper::getFioById($item['oper_id']) ?>)</span>
+        <?php endif; ?>
+
+        <?php if ($item['type'] == "unlink"): ?>
+            <i class="fas fa-unlink" style="color: #870404"></i>
+            <span style="color: #870404">(<?= HelperOper::getFioById($item['oper_id']) ?>)</span>
+        <?php endif; ?>
+
+        <span style="color: #999999"><?= $date->format(Date::FORMAT_DATE_TIME) ?></span>
+
+        <?php if ($item['type'] == "link"): ?>
+            Привязана
+        <?php endif; ?>
+
+        <?php if ($item['type'] == "unlink"): ?>
+            Отвязана
+        <?php endif; ?>
+
+        <?php if (isset($item['child_id'])): ?>
+            дочерняя задача: <?= Html::a(Req3Tasks::getNameDeletedHtml($item['child_id']), ['/process/task/view', 'id' => $item['child_id']], ['target' => "_blank"]) ?>
+        <?php endif; ?>
+
+        <?php if (isset($item['parent_id'])): ?>
+            родительская задача: <?= Html::a(Req3Tasks::getNameDeletedHtml($item['parent_id']), ['/process/task/view', 'id' => $item['parent_id']], ['target' => "_blank"]) ?>
+        <?php endif; ?>
+
+    </div>
+</div>

--- a/modules/process/views/task-archive/history/step.php
+++ b/modules/process/views/task-archive/history/step.php
@@ -1,0 +1,35 @@
+<?php
+use app\components\Date;
+use yii\helpers\Url;
+
+/* @var $this yii\web\View */
+/* @var $item array */
+/* @var $online array */
+
+$date = new Date($item['start_date']);
+$end_date = new Date($item['end_date']);
+$label = $item['label'] ?? null;
+?>
+
+<div>
+    <i class="fas fa-shoe-prints" style="background-color: #c5c5c5; color: #fafafa;"></i>
+    <div class="timeline-item clearfix" style="display: flex; gap: 10px; flex-wrap: wrap">
+        <div class="timeline-body" style="flex-grow:1; flex-basis: min-content;">
+            <div style="font-weight:bold; min-width:200px;">
+                <a href="<?= Url::toRoute(['/process/step/view', 'id' => $item['step_id']]) ?>" target="_blank">
+                    <?= $item['step_name'] ?? ('Шаг ' . $item['step_id']) ?>
+                </a>
+            </div>
+        </div>
+        <span class="time" style="margin-left:auto; white-space:nowrap">
+            <div>
+                <i class="fas fa-clock"></i>
+                <?php $sec = $date->subtractDateTime($end_date); ?>
+                <span><?= Date::secondsToText($sec, 2) ?></span>
+            </div>
+            <?php if ($label): ?>
+                <span class="badge badge-light" style="background-color: <?= $label['color'] ?>"><?= $label['label'] ?></span>
+            <?php endif; ?>
+        </span>
+    </div>
+</div>

--- a/modules/process/views/task-archive/history/time_label.php
+++ b/modules/process/views/task-archive/history/time_label.php
@@ -1,0 +1,17 @@
+<?php
+
+use app\components\Date;
+
+/* @var $this yii\web\View */
+/* @var $last_date string */
+/* @var $date_check string */
+?>
+
+<?php $date = new Date($date_check); ?>
+<?php if ($last_date != $date->format(Date::FORMAT_DATE_DB)): ?>
+    <?php $last_date = $date->format(Date::FORMAT_DATE_DB) ?>
+    <!-- timeline time label -->
+    <div class="time-label">
+        <span class="bg-cyan"><?= $date->format("d") . " " . $date->getMonthName() . " " . $date->format("Y") ?></span>
+    </div>
+<?php endif; ?>

--- a/modules/process/views/task-archive/history/transition_detail_info.php
+++ b/modules/process/views/task-archive/history/transition_detail_info.php
@@ -1,0 +1,34 @@
+<?php
+
+use app\components\Date;
+use app\modules\process\components\HelperOper;
+use app\modules\process\models\task\Req3Tasks;
+
+/* @var $this yii\web\View */
+/* @var $task Req3Tasks */
+/* @var $item array */
+
+$date = new Date($item['time_start']);
+?>
+
+<div style="margin-left: 60px; font-size: small; color: #9b9b9b" title="Детальная информация о переходе">
+    <div>
+        <i class="fas fa-clock"></i> <?= $date->format(Date::FORMAT_DATE_TIME) ?>
+        <span style="color: #9985af">(<?= HelperOper::getFioById($item['oper_id']) ?>)</span>
+    </div>
+
+    <?php if (isset($item['transition'])): ?>
+        <div>
+            <i class="fas fa-mouse" style="padding: 0 2px"></i>
+            Нажал на кнопку: <span style="color: #279eb9;"><?= $item['transition']['name'] ?></span> (старая система переходов)
+        </div>
+    <?php endif; ?>
+
+    <?php if (isset($item['ok']) && !$item['ok']): ?>
+        <div style="color: #d18353;">
+            <i class="fas fa-exclamation-triangle"></i>
+            переход не удался
+        </div>
+    <?php endif; ?>
+
+</div>

--- a/modules/process/views/task-archive/history/transition_info.php
+++ b/modules/process/views/task-archive/history/transition_info.php
@@ -1,0 +1,29 @@
+<?php
+use app\components\Date;
+use app\modules\process\components\HelperOper;
+
+/* @var $this yii\web\View */
+/* @var $item array */
+
+$date = new Date($item['start_date']);
+?>
+
+<div style="margin-left: 60px; font-size: small; color: #9b9b9b" title="Информация о переходе">
+    <div>
+        <i class="fas fa-clock"></i> <?= $date->format(Date::FORMAT_DATE_TIME) ?>
+        <?php if (!empty($item['oper_id'])): ?>
+            <span style="color: #9985af">(<?= HelperOper::getFioById($item['oper_id']) ?>)</span>
+        <?php endif; ?>
+    </div>
+</div>
+
+<?php if (!empty($item['from_task_name'])): ?>
+<div>
+    <i class="fas fa-directions" style="background-color: #458eb5; color: #fafafa;"></i>
+    <div class="timeline-item clearfix">
+        <div class="timeline-body">
+            БП запущен из другого БП: <?= $item['from_task_name'] ?>
+        </div>
+    </div>
+</div>
+<?php endif; ?>

--- a/modules/process/views/task-archive/history/transition_rule2_info.php
+++ b/modules/process/views/task-archive/history/transition_rule2_info.php
@@ -1,0 +1,37 @@
+<?php
+
+use app\components\Date;
+use app\modules\process\components\HelperOper;
+use app\modules\process\models\task\Req3Tasks;
+
+/* @var $this yii\web\View */
+/* @var $task Req3Tasks */
+/* @var $item array */
+
+$date = new Date($item['time_start']);
+?>
+
+<div style="margin-left: 60px; font-size: small; color: #9b9b9b" title="Детальная информация о переходе">
+    <div>
+        <i class="fas fa-clock"></i> <?= $date->format(Date::FORMAT_DATE_TIME) ?>
+        <span style="color: #9985af">(<?= HelperOper::getFioById($item['oper_id']) ?>)</span>
+    </div>
+
+    <?php if ($item['rule2_id']): ?>
+        <div>
+            <i class="fas fa-mouse" style="padding: 0 2px"></i>
+            Двинул задачу далее по маршруту #<?= $item['rule2_id'] ?>
+            <a href="#" onclick="showDialogStepRulesInfo(<?= $item['from_step_id'] ?>, <?= $task->id ?>, <?= $item['rule2_id'] ?>, <?= json_encode($item['triggeredRuleIds'] ?? []) ?>)">
+                (инфо)
+            </a>
+        </div>
+    <?php endif; ?>
+
+    <?php if (isset($item['ok']) && !$item['ok']): ?>
+        <div style="color: #d18353;">
+            <i class="fas fa-exclamation-triangle"></i>
+            переход не удался
+        </div>
+    <?php endif; ?>
+
+</div>

--- a/modules/process/views/task-archive/index.php
+++ b/modules/process/views/task-archive/index.php
@@ -1,0 +1,58 @@
+<?php
+use yii\helpers\Html;
+use yii\grid\GridView;
+use yii\widgets\ActiveForm;
+use app\widgets\Select2Template;
+use app\widgets\DateRangePickerWithRanges;
+
+/* @var $this yii\web\View */
+/* @var $searchModel app\modules\process\models\FormReq3SearchArchive */
+/* @var $dataProvider yii\data\ActiveDataProvider */
+
+$this->title = 'Архив задач';
+?>
+
+<div class="task-archive-index">
+    <h1><?= Html::encode($this->title) ?></h1>
+
+    <div class="task-archive-search mb-3">
+        <?php $form = ActiveForm::begin([
+            'method' => 'get',
+        ]); ?>
+
+        <?= $form->field($searchModel, 'template_id')->widget(Select2Template::class) ?>
+        <?= $form->field($searchModel, 'template_name') ?>
+        <?= $form->field($searchModel, 'dateRange', [
+            'addon'   => ['prepend' => ['content' => '<i class="fas fa-calendar-alt"></i>']],
+            'options' => ['class' => 'drp-container form-group']
+        ])->widget(DateRangePickerWithRanges::class, [
+            'unsetRanges' => ['Сегодня'],
+            'options'        => ['class' => 'form-control', 'autocomplete' => 'off'],
+            'useWithAddon'   => true,
+            'presetDropdown' => false,
+            'convertFormat'  => true,
+        ]); ?>
+
+        <div class="form-group">
+            <?= Html::submitButton('Поиск', ['class' => 'btn btn-primary']) ?>
+        </div>
+        <?php ActiveForm::end(); ?>
+    </div>
+
+    <?= GridView::widget([
+        'dataProvider' => $dataProvider,
+        'columns' => [
+            'task_id',
+            'task_name',
+            'template_name',
+            'task_date_create',
+            [
+                'class' => 'yii\grid\ActionColumn',
+                'template' => '{view}',
+                'urlCreator' => function ($action, $model) {
+                    return ['view', 'id' => $model->task_id];
+                }
+            ],
+        ],
+    ]); ?>
+</div>


### PR DESCRIPTION
## Summary
- add TaskArchiveController to list and view archived tasks
- introduce FormReq3SearchArchive search model with date range validation
- provide views for browsing archived tasks and timeline

## Testing
- `php -l modules/process/controllers/TaskArchiveController.php`
- `php -l modules/process/models/FormReq3SearchArchive.php`
- `php -l modules/process/models/task_archive/TaskArchive.php`
- `php -l modules/process/views/task-archive/index.php`
- `php -l modules/process/views/task-archive/history.php`
- `php -l modules/process/views/task-archive/history/step.php`
- `php -l modules/process/views/task-archive/history/transition_info.php`
- `php -l modules/process/views/task-archive/history/transition_detail_info.php`
- `php -l modules/process/views/task-archive/history/transition_rule2_info.php`
- `php -l modules/process/views/task-archive/history/info.php`
- `php -l modules/process/views/task-archive/history/link.php`
- `php -l modules/process/views/task-archive/history/function.php`
- `php -l modules/process/views/task-archive/history/data_changed.php`
- `php -l modules/process/views/task-archive/history/time_label.php`


------
https://chatgpt.com/codex/tasks/task_e_68a72a1529648321bb337f234e598c49