### PR TITLE
refactor: simplify task archive listing

### DIFF
--- a/modules/process/controllers/TaskArchiveController.php
+++ b/modules/process/controllers/TaskArchiveController.php
@@ -5,7 +5,7 @@ namespace app\modules\process\controllers;
 use app\controllers\BaseController;
 use app\modules\process\models\task_archive\TaskArchive;
 use app\modules\process\models\FormReq3SearchArchive;
-use yii\web\Controller;
+use yii\data\Pagination;
 use yii\web\NotFoundHttpException;
 use Yii;
 
@@ -13,12 +13,24 @@ class TaskArchiveController extends BaseController
 {
     public function actionIndex()
     {
-        $searchModel = new FormReq3SearchArchive();
-        $dataProvider = $searchModel->search(Yii::$app->request->queryParams);
+        $model = new FormReq3SearchArchive();
+        $model->load(Yii::$app->request->get(), '');
+
+        $query = $model->find();
+
+        $pager = new Pagination();
+        $pager->pageSize = 50;
+        $pager->totalCount = $query->count();
+
+        $query->limit($pager->limit);
+        $query->offset($pager->offset);
+
+        $tasks = $query->orderBy(['task_id' => SORT_DESC])->all();
 
         return $this->render('index', [
-            'searchModel' => $searchModel,
-            'dataProvider' => $dataProvider,
+            'model' => $model,
+            'tasks' => $tasks,
+            'pager' => $pager,
         ]);
     }
 

--- a/modules/process/models/FormReq3SearchArchive.php
+++ b/modules/process/models/FormReq3SearchArchive.php
@@ -3,7 +3,6 @@
 namespace app\modules\process\models;
 
 use yii\base\Model;
-use yii\data\ActiveDataProvider;
 use app\modules\process\models\task_archive\TaskArchive;
 
 class FormReq3SearchArchive extends Model
@@ -36,11 +35,10 @@ class FormReq3SearchArchive extends Model
         }
     }
 
-    public function search(array $params): ActiveDataProvider
+    public function find()
     {
         $query = TaskArchive::find();
 
-        $this->load($params);
         if (!$this->validate()) {
             $query->where('0=1');
         } else {
@@ -56,11 +54,6 @@ class FormReq3SearchArchive extends Model
             }
         }
 
-        return new ActiveDataProvider([
-            'query' => $query,
-            'sort' => [
-                'defaultOrder' => ['task_id' => SORT_DESC],
-            ],
-        ]);
+        return $query;
     }
 }

--- a/modules/process/views/task-archive/index.php
+++ b/modules/process/views/task-archive/index.php
@@ -2,13 +2,14 @@
 
 use app\modules\process\widgets\Select2Template;
 use kartik\widgets\ActiveForm;
+use yii\bootstrap4\LinkPager;
 use yii\helpers\Html;
-use yii\grid\GridView;
 use app\widgets\DateRangePickerWithRanges;
 
 /* @var $this yii\web\View */
-/* @var $searchModel app\modules\process\models\FormReq3SearchArchive */
-/* @var $dataProvider yii\data\ActiveDataProvider */
+/* @var $model app\modules\process\models\FormReq3SearchArchive */
+/* @var $tasks app\modules\process\models\task_archive\TaskArchive[] */
+/* @var $pager yii\data\Pagination */
 
 $this->title = 'Архив задач';
 ?>
@@ -21,9 +22,9 @@ $this->title = 'Архив задач';
             'method' => 'get',
         ]); ?>
 
-        <?= $form->field($searchModel, 'template_id')->widget(Select2Template::class) ?>
-        <?= $form->field($searchModel, 'template_name') ?>
-        <?= $form->field($searchModel, 'dateRange', [
+        <?= $form->field($model, 'template_id')->widget(Select2Template::class) ?>
+        <?= $form->field($model, 'template_name') ?>
+        <?= $form->field($model, 'dateRange', [
             'addon'   => ['prepend' => ['content' => '<i class="fas fa-calendar-alt"></i>']],
             'options' => ['class' => 'drp-container form-group']
         ])->widget(DateRangePickerWithRanges::class, [
@@ -40,20 +41,28 @@ $this->title = 'Архив задач';
         <?php ActiveForm::end(); ?>
     </div>
 
-    <?= GridView::widget([
-        'dataProvider' => $dataProvider,
-        'columns' => [
-            'task_id',
-            'task_name',
-            'template_name',
-            'task_date_create',
-            [
-                'class' => 'yii\grid\ActionColumn',
-                'template' => '{view}',
-                'urlCreator' => function ($action, $model) {
-                    return ['view', 'id' => $model->task_id];
-                }
-            ],
-        ],
-    ]); ?>
+    <table class="table table-bordered table-striped">
+        <thead>
+        <tr>
+            <th>ID</th>
+            <th>Название</th>
+            <th>Шаблон</th>
+            <th>Дата создания</th>
+            <th></th>
+        </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($tasks as $task): ?>
+            <tr>
+                <td><?= Html::encode($task->task_id) ?></td>
+                <td><?= Html::encode($task->task_name) ?></td>
+                <td><?= Html::encode($task->template_name) ?></td>
+                <td><?= Html::encode($task->task_date_create) ?></td>
+                <td><?= Html::a('Просмотр', ['view', 'id' => $task->task_id]) ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+
+    <?= LinkPager::widget(['pagination' => $pager]); ?>
 </div>


### PR DESCRIPTION
## Summary
- move archive search query logic into FormReq3SearchArchive::find and invoke it from TaskArchiveController

## Testing
- `php -l modules/process/controllers/TaskArchiveController.php`
- `php -l modules/process/models/FormReq3SearchArchive.php`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a7309f2d1883218953c8032b5d8c1d