### PR TITLE
Style task archive pages with Bootstrap cards

### DIFF
--- a/modules/process/controllers/TaskArchiveController.php
+++ b/modules/process/controllers/TaskArchiveController.php
@@ -46,7 +46,7 @@ class TaskArchiveController extends BaseController
             $items = json_decode($model->data_json, true) ?: [];
         }
 
-        return $this->render('history', [
+        return $this->render('view', [
             'task' => $model,
             'items' => $items,
         ]);

--- a/modules/process/views/task-archive/index.php
+++ b/modules/process/views/task-archive/index.php
@@ -17,28 +17,32 @@ $this->title = 'Архив задач';
 <div class="task-archive-index">
     <h1><?= Html::encode($this->title) ?></h1>
 
-    <div class="task-archive-search mb-3">
-        <?php $form = ActiveForm::begin([
-            'method' => 'get',
-        ]); ?>
+    <div class="card mb-3">
+        <div class="card-body">
+            <div class="task-archive-search">
+                <?php $form = ActiveForm::begin([
+                    'method' => 'get',
+                ]); ?>
 
-        <?= $form->field($model, 'templateId')->widget(Select2Template::class) ?>
-        <?= $form->field($model, 'templateName') ?>
-        <?= $form->field($model, 'dateRange', [
-            'addon'   => ['prepend' => ['content' => '<i class="fas fa-calendar-alt"></i>']],
-            'options' => ['class' => 'drp-container form-group']
-        ])->widget(DateRangePickerWithRanges::class, [
-            'unsetRanges' => ['Сегодня'],
-            'options'        => ['class' => 'form-control', 'autocomplete' => 'off'],
-            'useWithAddon'   => true,
-            'presetDropdown' => false,
-            'convertFormat'  => true,
-        ]); ?>
+                <?= $form->field($model, 'templateId')->widget(Select2Template::class) ?>
+                <?= $form->field($model, 'templateName') ?>
+                <?= $form->field($model, 'dateRange', [
+                    'addon'   => ['prepend' => ['content' => '<i class="fas fa-calendar-alt"></i>']],
+                    'options' => ['class' => 'drp-container form-group']
+                ])->widget(DateRangePickerWithRanges::class, [
+                    'unsetRanges' => ['Сегодня'],
+                    'options'        => ['class' => 'form-control', 'autocomplete' => 'off'],
+                    'useWithAddon'   => true,
+                    'presetDropdown' => false,
+                    'convertFormat'  => true,
+                ]); ?>
 
-        <div class="form-group">
-            <?= Html::submitButton('Поиск', ['class' => 'btn btn-primary']) ?>
+                <div class="form-group">
+                    <?= Html::submitButton('Поиск', ['class' => 'btn btn-primary']) ?>
+                </div>
+                <?php ActiveForm::end(); ?>
+            </div>
         </div>
-        <?php ActiveForm::end(); ?>
     </div>
 
     <?php foreach ($tasks as $task): ?>

--- a/modules/process/views/task-archive/view.php
+++ b/modules/process/views/task-archive/view.php
@@ -1,0 +1,32 @@
+<?php
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+/* @var $task app\modules\process\models\task_archive\TaskArchive */
+/* @var $items array */
+
+$this->title = $task->task_name;
+?>
+
+<div class="task-archive-view">
+    <div class="card mb-3">
+        <div class="card-header">
+            <?= Html::encode($task->task_name) ?>
+        </div>
+        <div class="card-body">
+            <p class="mb-0"><strong>Шаблон:</strong> <?= Html::encode($task->template_name) ?></p>
+        </div>
+    </div>
+
+    <div data-history-card="1" class="card">
+        <div class="card-header" data-spoiler data-container="[data-history-card]" data-content="[data-history-content]">
+            История
+            <i class="fas fa-caret-up" data-open="1"></i>
+            <i class="fas fa-caret-down" data-close="1"></i>
+        </div>
+        <div class="card-body" data-history-content="1" style="display: none">
+            <?= $this->render('history', ['task' => $task, 'items' => $items]) ?>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- Wrap task archive search form in Bootstrap card
- Adjust controller to render dedicated view for archive items
- Add task archive detail view with general info card and collapsible history

## Testing
- `php -l modules/process/views/task-archive/index.php`
- `php -l modules/process/controllers/TaskArchiveController.php`
- `php -l modules/process/views/task-archive/view.php`


------
https://chatgpt.com/codex/tasks/task_e_68a75343dc508321a05c0471d7c32d96