### PR TITLE
Добавлена сводка времени выполнения в архив задач

### DIFF
--- a/modules/process/controllers/TaskArchiveController.php
+++ b/modules/process/controllers/TaskArchiveController.php
@@ -42,13 +42,28 @@ class TaskArchiveController extends BaseController
         }
 
         $items = [];
+        $timeExecute = null;
+        $deviationInfo = [];
+        $timeTemplate = null;
+
         if (!empty($model->data_json)) {
-            $items = json_decode($model->data_json, true) ?: [];
+            $data = json_decode($model->data_json, true) ?: [];
+            if (isset($data['items'])) {
+                $items = $data['items'];
+                $timeExecute = $data['time_execute'] ?? null;
+                $deviationInfo = $data['deviation_info'] ?? [];
+                $timeTemplate = $data['time_template'] ?? null;
+            } else {
+                $items = $data;
+            }
         }
 
         return $this->render('view', [
             'task' => $model,
             'items' => $items,
+            'timeExecute' => $timeExecute,
+            'deviationInfo' => $deviationInfo,
+            'timeTemplate' => $timeTemplate,
         ]);
     }
 }

--- a/modules/process/services/ProcessTaskArchiveService.php
+++ b/modules/process/services/ProcessTaskArchiveService.php
@@ -150,7 +150,16 @@ class ProcessTaskArchiveService
             }
         }
 
-        return $items;
+        $timeExecute = $task->getTimeExecute();
+        $deviationInfo = $task->getDeviationInfo();
+        $timeTemplate = ($task->version->execute_minutes ?? 0) * 60;
+
+        return [
+            'items'          => $items,
+            'time_execute'   => $timeExecute,
+            'deviation_info' => $deviationInfo,
+            'time_template'  => $timeTemplate,
+        ];
     }
 
     protected function buildTransitionItem(Req3TasksStepHistory $history): array

--- a/modules/process/views/task-archive/history.php
+++ b/modules/process/views/task-archive/history.php
@@ -1,10 +1,62 @@
 <?php
+use app\components\Date;
+use app\models\Opers;
+
 /* @var $this yii\web\View */
 /* @var $task app\modules\process\models\task_archive\TaskArchive */
 /* @var $items array */
+/* @var $timeExecute array|null */
+/* @var $deviationInfo array */
+/* @var $timeTemplate int|null */
+
+$color_time_execute_all = "#1f1f1f";
+$color_time_active = "#44AC10";
+$color_time_deviation = "#CD3333";
+$color_time_auto = "#1063AC";
+$color_time_not_working = "#8F8F8F";
 ?>
 
 <div data-step-history="1">
+    <div class="card card-small" style="overflow: hidden">
+        <div class="card-body">
+            <div><span style="color:<?= $color_time_execute_all ?>; font-weight: bold">Всего на задачу ушло:</span> <?= Date::secondsToText($timeExecute['all_time'] ?? 0, 2) ?></div>
+            <?php if (($timeExecute['active_time'] ?? 0) > 0): ?>
+                <div><span style="color: <?= $color_time_active ?>; font-weight: bold">Активное время:</span> <?= Date::secondsToText($timeExecute['active_time'], 2) ?></div>
+            <?php endif; ?>
+            <?php if (($timeExecute['deviation_time'] ?? 0) > 0 || ($deviationInfo['all'] ?? 0) > 0): ?>
+                <div>
+                    <span style="color: <?= $color_time_deviation ?>; font-weight: bold">Отклонения:</span> <?= Date::secondsToText($timeExecute['deviation_time'] ?? 0, 2) ?>
+                    <span style="color: #ca2727">(отклонений по задаче: <b><?= $deviationInfo['all'] ?? 0 ?></b> (шаг: <b><?= $deviationInfo['steps'] ?? 0 ?></b> + маршрут: <b><?= $deviationInfo['rules'] ?? 0 ?></b>))</span>
+                </div>
+            <?php endif; ?>
+            <?php if (($timeExecute['auto_time'] ?? 0) > 0): ?>
+                <div><span style="color: <?= $color_time_auto ?>; font-weight: bold">Автоматические шаги:</span> <?= Date::secondsToText($timeExecute['auto_time'], 2) ?></div>
+            <?php endif; ?>
+            <?php if (($timeExecute['not_working_time'] ?? 0) > 0): ?>
+                <div><span style="color: <?= $color_time_not_working ?>; font-weight: bold">Не рабочее время:</span> <?= Date::secondsToText($timeExecute['not_working_time'], 2) ?></div>
+            <?php endif; ?>
+            <?php if (($timeTemplate ?? 0) > 0): ?>
+                <div><span style="color: #0023a6; font-weight: bold">На решение задачи даётся активного времени:</span> <?= Date::secondsToText($timeTemplate, 2) ?></div>
+            <?php endif; ?>
+            <?php if (!empty($timeExecute['opers'])): ?>
+                <div data-view-online="1">
+                    <div style="color: #aeaeae; font-weight: bold" data-spoiler data-container="[data-view-online]" data-content="[data-spoiler-content-online]">
+                        Сколько времени исполнители были в задаче
+                        <i class="fas fa-caret-up" data-open="1"></i>
+                        <i class="fas fa-caret-down" data-close="1"></i>
+                    </div>
+                    <div data-spoiler-content-online="1" style="display: none">
+                        <?php foreach ($timeExecute['opers'] as $oper_id => $second): ?>
+                            <div>
+                                <span style="color: #d36148; font-weight: bold;"><?= Opers::getFioOrFioDeletedHtmlById($oper_id) ?></span>: <?= Date::secondsToText($second, 2) ?>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+            <?php endif; ?>
+        </div>
+    </div>
+
     <div class="timeline">
         <?php $last_date = null; ?>
         <?php foreach ($items as $item): ?>

--- a/modules/process/views/task-archive/view.php
+++ b/modules/process/views/task-archive/view.php
@@ -6,6 +6,9 @@ use yii\helpers\Html;
 /* @var $this yii\web\View */
 /* @var $task app\modules\process\models\task_archive\TaskArchive */
 /* @var $items array */
+/* @var $timeExecute array|null */
+/* @var $deviationInfo array */
+/* @var $timeTemplate int|null */
 
 $this->title = "Архив: ".$task->task_name;
 $this->params['breadcrumbs'][] = ['label' => "Архив", 'url' => ['index']];
@@ -39,7 +42,13 @@ $statusLabel = $statuses[$task->step_last_status] ?? $task->step_last_status;
             <i class="fas fa-caret-down" data-close="1"></i>
         </div>
         <div class="card-body" data-history-content="1" style="display: none; background: #dedede">
-            <?= $this->render('history', ['task' => $task, 'items' => $items]) ?>
+            <?= $this->render('history', [
+                'task' => $task,
+                'items' => $items,
+                'timeExecute' => $timeExecute,
+                'deviationInfo' => $deviationInfo,
+                'timeTemplate' => $timeTemplate,
+            ]) ?>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- Сохранение времени выполнения и отклонений при архивации задач
- Отображение сводки времени в архивном просмотре истории

## Testing
- `php -l modules/process/services/ProcessTaskArchiveService.php`
- `php -l modules/process/controllers/TaskArchiveController.php`
- `php -l modules/process/views/task-archive/history.php`
- `php -l modules/process/views/task-archive/view.php`
- `composer test` *(fails: Command "test" is not defined)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a75e6cdfbc8321a9d0d78b47f75da3