### PR TITLE
Archive tasks with identifier data

### DIFF
--- a/modules/process/controllers/TaskArchiveController.php
+++ b/modules/process/controllers/TaskArchiveController.php
@@ -4,7 +4,9 @@ namespace app\modules\process\controllers;
 
 use app\controllers\BaseController;
 use app\modules\process\models\FormReq3SearchArchive;
+use app\modules\process\models\identifiers\Req3Identifiers;
 use app\modules\process\models\task_archive\TaskArchive;
+use app\modules\process\models\task_data\Req3TasksDataItems;
 use Yii;
 use yii\data\Pagination;
 use yii\web\NotFoundHttpException;
@@ -45,6 +47,8 @@ class TaskArchiveController extends BaseController
         $timeExecute = null;
         $deviationInfo = [];
         $timeTemplate = null;
+        $dataItems = [];
+        $identifiers = [];
 
         if (!empty($model->data_json)) {
             $data = json_decode($model->data_json, true) ?: [];
@@ -52,6 +56,26 @@ class TaskArchiveController extends BaseController
             $timeExecute = $data['time_execute'] ?? null;
             $deviationInfo = $data['deviation_info'] ?? [];
             $timeTemplate = $data['time_template'] ?? null;
+
+            if (!empty($data['data_items']) && is_array($data['data_items'])) {
+                $ids = [];
+                foreach ($data['data_items'] as $row) {
+                    $item = new Req3TasksDataItems([
+                        'id'            => $row['id'] ?? null,
+                        'identifier_id' => $row['identifier_id'] ?? null,
+                        'type'          => $row['type'] ?? null,
+                        'value_id'      => $row['value_id'] ?? null,
+                        'value_text'    => $row['value_text'] ?? null,
+                        'value_number'  => $row['value_number'] ?? null,
+                        'oper_id'       => $row['oper_id'] ?? null,
+                    ]);
+                    $dataItems[$item->identifier_id][] = $item;
+                    $ids[$item->identifier_id] = $item->identifier_id;
+                }
+                if (!empty($ids)) {
+                    $identifiers = Req3Identifiers::find()->where(['id' => array_keys($ids)])->indexBy('id')->all();
+                }
+            }
         }
 
         return $this->render('view', [
@@ -60,6 +84,8 @@ class TaskArchiveController extends BaseController
             'timeExecute' => $timeExecute,
             'deviationInfo' => $deviationInfo,
             'timeTemplate' => $timeTemplate,
+            'dataItems' => $dataItems,
+            'identifiers' => $identifiers,
         ]);
     }
 }

--- a/modules/process/services/ProcessTaskArchiveService.php
+++ b/modules/process/services/ProcessTaskArchiveService.php
@@ -159,11 +159,25 @@ class ProcessTaskArchiveService
         $deviationInfo = $task->getDeviationInfo();
         $timeTemplate = ($task->version->execute_minutes ?? 0) * 60;
 
+        $dataItems = [];
+        foreach ($task->data as $item) {
+            $dataItems[] = [
+                'id'            => $item->id,
+                'identifier_id' => $item->identifier_id,
+                'type'          => $item->type,
+                'value_id'      => $item->value_id,
+                'value_text'    => $item->value_text,
+                'value_number'  => $item->value_number,
+                'oper_id'       => $item->oper_id,
+            ];
+        }
+
         return [
-            'history'          => $items,
+            'history'        => $items,
             'time_execute'   => $timeExecute,
             'deviation_info' => $deviationInfo,
             'time_template'  => $timeTemplate,
+            'data_items'     => $dataItems,
         ];
 
     }

--- a/modules/process/views/task-archive/view.php
+++ b/modules/process/views/task-archive/view.php
@@ -1,6 +1,7 @@
 <?php
 
 use app\modules\process\models\template_steps\Req3TemplateSteps;
+use app\modules\process\widgets\IdentifierViewWidget;
 use yii\helpers\Html;
 
 /* @var $this yii\web\View */
@@ -9,6 +10,8 @@ use yii\helpers\Html;
 /* @var $timeExecute array|null */
 /* @var $deviationInfo array */
 /* @var $timeTemplate int|null */
+/* @var $identifiers app\modules\process\models\identifiers\Req3Identifiers[] */
+/* @var $dataItems app\modules\process\models\task_data\Req3TasksDataItems[][] */
 
 $this->title = "Архив: ".$task->task_name;
 $this->params['breadcrumbs'][] = ['label' => "Архив", 'url' => ['index']];
@@ -34,6 +37,22 @@ $statusLabel = $statuses[$task->step_last_status] ?? $task->step_last_status;
             <p class="mb-0"><strong>Дата добавления в архив:</strong> <?= $task->date_add_to_archive ?></p>
         </div>
     </div>
+
+    <?php if (!empty($identifiers)): ?>
+        <div class="card mb-3">
+            <div class="card-header">Данные</div>
+            <div class="card-body">
+                <?php foreach ($identifiers as $identifierId => $identifier): ?>
+                    <?= IdentifierViewWidget::widget([
+                        'identification' => Yii::$app->user->identity,
+                        'identifier' => $identifier,
+                        'forced_data' => $dataItems[$identifierId] ?? [],
+                        'is_only_view' => true,
+                    ]) ?>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    <?php endif; ?>
 
     <div data-history-card="1" class="card">
         <div class="card-header" data-spoiler data-container="[data-history-card]" data-content="[data-history-content]">

--- a/modules/process/widgets/IdentifierViewWidget.php
+++ b/modules/process/widgets/IdentifierViewWidget.php
@@ -65,8 +65,8 @@ class IdentifierViewWidget extends Widget
 
         $oper = Opers::getOperByData($this->identification);
 
-        $can_edit = $this->task && $oper && $this->task->isAccessAction($oper);
-        $canLike = ($this->task && $oper && $this->task->isAccessView($oper)) || ($oper && Yii::$app->authManager->checkAccess($oper->oper_id, "business.like"));
+        $can_edit = !$this->is_only_view && $this->task && $oper && $this->task->isAccessAction($oper);
+        $canLike = !$this->is_only_view && (($this->task && $oper && $this->task->isAccessView($oper)) || ($oper && Yii::$app->authManager->checkAccess($oper->oper_id, "business.like")));
 
         $setting = $this->identifier->getSettingArray();
         $setting_limit_days = null;
@@ -164,7 +164,7 @@ class IdentifierViewWidget extends Widget
         if ($this->identifier->type == Req3Identifiers::TYPE_REWARDS) {
             $values = count($values) > 0 ? $values : [new Req3TasksDataItems(['type' => Req3Identifiers::TYPE_REWARDS, 'identifier_id' => $this->identifier->id])];
         }
-        if ($this->identifier->type == Req3Identifiers::TYPE_CALL_STATUS && count($this->task->calls_statuses ?? []) > 0) {
+        if ($this->task && $this->identifier->type == Req3Identifiers::TYPE_CALL_STATUS && count($this->task->calls_statuses ?? []) > 0) {
             $values = [new Req3TasksDataItems(['type' => Req3Identifiers::TYPE_CALL_STATUS, 'identifier_id' => $this->identifier->id])];
         }
         if ($this->identifier->type == Req3Identifiers::TYPE_GHOST) {
@@ -174,8 +174,8 @@ class IdentifierViewWidget extends Widget
         //-------------------------------------------
 
         $is_has_history = false;
-        if ($this->forced_data === null) {
-            foreach ($this->task->data_history ?? [] as $value) {
+        if ($this->forced_data === null && $this->task) {
+            foreach ($this->task->data_history as $value) {
                 if ($value->identifier_id == $this->identifier->id && $value->type == $this->identifier->type) {
                     $is_has_history = true;
                     break;


### PR DESCRIPTION
## Summary
- Include essential Req3TasksDataItems fields in archived task JSON for later restoration
- Harden IdentifierViewWidget to support view-only mode and avoid accessing missing task data
- Persist all task data items without filtering by archiveIdentifiers
- Render archived identifier values in task-archive view

## Testing
- `php -l modules/process/services/ProcessTaskArchiveService.php`
- `php -l modules/process/widgets/IdentifierViewWidget.php`
- `php -l modules/process/controllers/TaskArchiveController.php`
- `php -l modules/process/views/task-archive/view.php`


------
https://chatgpt.com/codex/tasks/task_e_68a867334294832198218f92380fd0cc