### PR TITLE
Enable configurable identifier mapping in process2 module

### DIFF
--- a/config/di.php
+++ b/config/di.php
@@ -1,11 +1,3 @@
 <?php
 
-use app\modules\process2\services\data\DataItemIdentifierRegistry;
-
-return [
-    'container' => [
-        'singletons' => [
-            DataItemIdentifierRegistry::class => DataItemIdentifierRegistry::class,
-        ],
-    ],
-];
+return [];

--- a/config/params.php
+++ b/config/params.php
@@ -1,13 +1,3 @@
 <?php
 
-use app\modules\process2\components\identifier\{type\IdentifierTariff};
-use app\modules\process2\components\identifier\type\IdentifierService;
-use app\modules\process2\components\identifier\type\IdentifierUser;
-
-return [
-    'identifiers' => [
-        50 => IdentifierUser::class,
-        60 => IdentifierTariff::class,
-        61 => IdentifierService::class,
-    ],
-];
+return [];

--- a/modules/process2/ProcessModule.php
+++ b/modules/process2/ProcessModule.php
@@ -3,19 +3,56 @@
 namespace app\modules\process2;
 
 use app\modules\process\assets\ProcessAsset;
+use app\modules\process2\services\data\DataItemIdentifierRegistry;
+use app\modules\process2\services\data\IdentifierMapProvider;
+use app\modules\process2\services\data\IdentifierPresetRegistry;
+use app\modules\process2\services\data\LazyFinalMapProvider;
 use Yii;
+use yii\base\BootstrapInterface;
 use yii\base\Module;
 use yii\web\Application as WebApplication;
 
-class ProcessModule extends Module
+class ProcessModule extends Module implements BootstrapInterface
 {
     public function init()
     {
         parent::init();
         Yii::configure($this, require(__DIR__ . '/config/web.php'));
+        Yii::configure(Yii::$container, require(__DIR__ . '/config/di.php'));
 
         if (Yii::$app instanceof WebApplication) {
             ProcessAsset::register(Yii::$app->view);
+        }
+    }
+
+    public function bootstrap($app)
+    {
+        $c = Yii::$container;
+
+        if (!$c->has(IdentifierPresetRegistry::class, true)) {
+            $c->setSingleton(IdentifierPresetRegistry::class, IdentifierPresetRegistry::class);
+        }
+
+        $baseMap = (require __DIR__ . '/config/identifiers.php')['identifiers'] ?? [];
+        $c->get(IdentifierPresetRegistry::class)->add('process2/base', $baseMap);
+
+        if ($c->has(IdentifierMapProvider::class, true)) {
+            return;
+        }
+
+        $includes = $app->params['process.identifiers.includes'] ?? '*';
+        $overrides = $app->params['process.identifiers.map'] ?? [];
+
+        $c->setSingleton(IdentifierMapProvider::class, function () use ($c, $includes, $overrides) {
+            return new LazyFinalMapProvider(
+                $c->get(IdentifierPresetRegistry::class),
+                $includes,
+                $overrides
+            );
+        });
+
+        if (!$c->has(DataItemIdentifierRegistry::class, true)) {
+            $c->setSingleton(DataItemIdentifierRegistry::class, DataItemIdentifierRegistry::class);
         }
     }
 }

--- a/modules/process2/config/di.php
+++ b/modules/process2/config/di.php
@@ -1,0 +1,16 @@
+<?php
+
+use app\modules\process2\services\data\DataItemIdentifierRegistry;
+use yii\helpers\ArrayHelper;
+
+$di = [
+    'singletons' => [
+        DataItemIdentifierRegistry::class => DataItemIdentifierRegistry::class,
+    ],
+];
+
+if (file_exists(__DIR__ . DIRECTORY_SEPARATOR . 'di.local.php')) {
+    $di = ArrayHelper::merge($di, require __DIR__ . DIRECTORY_SEPARATOR . 'di.local.php');
+}
+
+return $di;

--- a/modules/process2/config/identifiers.php
+++ b/modules/process2/config/identifiers.php
@@ -1,0 +1,13 @@
+<?php
+
+use app\modules\process2\components\identifier\type\IdentifierService;
+use app\modules\process2\components\identifier\type\IdentifierTariff;
+use app\modules\process2\components\identifier\type\IdentifierUser;
+
+return [
+    'identifiers' => [
+        50 => IdentifierUser::class,
+        60 => IdentifierTariff::class,
+        61 => IdentifierService::class,
+    ],
+];

--- a/modules/process2/config/web.php
+++ b/modules/process2/config/web.php
@@ -3,9 +3,7 @@
 use yii\helpers\ArrayHelper;
 
 $config = [
-    'params' => [
-
-    ]
+    'params' => [],
 ];
 
 if (file_exists(__DIR__ . DIRECTORY_SEPARATOR . 'web.local.php')) {

--- a/modules/process2/services/data/DataItemIdentifierRegistry.php
+++ b/modules/process2/services/data/DataItemIdentifierRegistry.php
@@ -4,19 +4,19 @@ namespace app\modules\process2\services\data;
 
 use app\modules\process2\components\identifier\BaseIdentifier;
 use app\modules\process2\dto\data\DataItemDto;
+use app\modules\process2\services\data\IdentifierMapProvider;
 use app\modules\process2\services\data\loader\DataItemLoaderInterface;
 use Yii;
+
 
 class DataItemIdentifierRegistry
 {
     /** @var array<int, class-string<BaseIdentifier>> */
     private array $map;
 
-    public function __construct()
+    public function __construct(IdentifierMapProvider $provider)
     {
-        /** @var array<int, class-string<BaseIdentifier>> $config */
-        $config = Yii::$app->params['identifiers'] ?? [];
-        $this->map = $config;
+        $this->map = $provider->getMap();
     }
 
     /** @var array<string, DataItemLoaderInterface> */

--- a/modules/process2/services/data/IdentifierMapProvider.php
+++ b/modules/process2/services/data/IdentifierMapProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace app\modules\process2\services\data;
+
+use app\modules\process2\components\identifier\BaseIdentifier;
+
+interface IdentifierMapProvider
+{
+    /**
+     * @return array<int, class-string<BaseIdentifier>>
+     */
+    public function getMap(): array;
+}

--- a/modules/process2/services/data/IdentifierPresetRegistry.php
+++ b/modules/process2/services/data/IdentifierPresetRegistry.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace app\modules\process2\services\data;
+
+use app\modules\process2\components\identifier\BaseIdentifier;
+
+final class IdentifierPresetRegistry
+{
+    /**
+     * @var array<string, array<int, class-string<BaseIdentifier>>>
+     */
+    private array $presets = [];
+
+    /**
+     * @param array<int, class-string<BaseIdentifier>> $map
+     */
+    public function add(string $name, array $map): void
+    {
+        $this->presets[$name] = $map;
+    }
+
+    /**
+     * @return array<int, class-string<BaseIdentifier>>
+     */
+    public function get(string $name): array
+    {
+        return $this->presets[$name] ?? [];
+    }
+
+    /**
+     * @return array<string, array<int, class-string<BaseIdentifier>>>
+     */
+    public function all(): array
+    {
+        return $this->presets;
+    }
+}

--- a/modules/process2/services/data/LazyFinalMapProvider.php
+++ b/modules/process2/services/data/LazyFinalMapProvider.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace app\modules\process2\services\data;
+
+use app\modules\process2\components\identifier\BaseIdentifier;
+
+/**
+ * Builds the final identifier map on first access, after all presets are registered.
+ */
+final class LazyFinalMapProvider implements IdentifierMapProvider
+{
+    /** @var array<int, class-string<BaseIdentifier>>|null */
+    private ?array $map = null;
+
+    /**
+     * @param array<string>|string $includes Names of presets to include or '*' for all
+     * @param array<int, class-string<BaseIdentifier>> $overrides Final overrides from application config
+     */
+    public function __construct(
+        private IdentifierPresetRegistry $registry,
+        private array|string $includes = '*',
+        private array $overrides = [],
+    ) {
+    }
+
+    public function getMap(): array
+    {
+        if ($this->map !== null) {
+            return $this->map;
+        }
+
+        $final  = [];
+        $seenBy = [];
+
+        $names = $this->includes === '*'
+            ? array_keys($this->registry->all())
+            : (array) $this->includes;
+
+        foreach ($names as $name) {
+            foreach ($this->registry->get($name) as $id => $class) {
+                if (isset($final[$id])) {
+                    $prev = $seenBy[$id] ?? 'unknown';
+                    throw new \RuntimeException(
+                        "Duplicate identifier id {$id} between presets '{$prev}' and '{$name}'."
+                    );
+                }
+                $final[$id]  = $class;
+                $seenBy[$id] = $name;
+            }
+        }
+
+        foreach ($this->overrides as $id => $class) {
+            $final[$id]  = $class;
+            $seenBy[$id] = 'override';
+        }
+
+        return $this->map = $final;
+    }
+}


### PR DESCRIPTION
## Summary
- Add preset registry and array-based provider to supply identifier mappings
- Bootstrap process2 to assemble final identifier map from app params and register registry
- Switch DataItemIdentifierRegistry to use IdentifierMapProvider
- Build identifier map lazily via LazyFinalMapProvider, including all presets by default and applying overrides

## Testing
- `php -l modules/process2/services/data/LazyFinalMapProvider.php`
- `php -l modules/process2/ProcessModule.php`
- `php -l modules/process2/services/data/DataItemIdentifierRegistry.php`


------
https://chatgpt.com/codex/tasks/task_e_68acbe6d6b6c832185ed2836ceedf67e