### PR TITLE
feat(process2): add preset-based identifier DI

### DIFF
--- a/modules/process2/config/web.php
+++ b/modules/process2/config/web.php
@@ -3,7 +3,9 @@
 use yii\helpers\ArrayHelper;
 
 $config = [
-    'params' => [],
+    'identifierIncludes'  => '*',
+    'identifierOverrides' => [],
+    'params'              => [],
 ];
 
 if (file_exists(__DIR__ . DIRECTORY_SEPARATOR . 'web.local.php')) {

--- a/modules/process2/services/data/BasicIdentifierMapValidator.php
+++ b/modules/process2/services/data/BasicIdentifierMapValidator.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace app\modules\process2\services\data;
+
+use app\modules\process2\components\identifier\BaseIdentifier;
+
+final class BasicIdentifierMapValidator implements IdentifierMapValidator
+{
+    public function __construct(private string $baseClass = BaseIdentifier::class)
+    {
+    }
+
+    public function validatePreset(string $presetName, array $map): void
+    {
+        foreach ($map as $id => $class) {
+            if (!is_int($id)) {
+                throw new IdentifierConfigException(
+                    "Preset {$presetName}: key must be int, got " . gettype($id)
+                );
+            }
+            if (!is_string($class)) {
+                throw new IdentifierConfigException(
+                    "Preset {$presetName}: value must be class-string"
+                );
+            }
+        }
+    }
+
+    public function validateFinal(array $finalMap): void
+    {
+        foreach ($finalMap as $id => $class) {
+            if (!class_exists($class)) {
+                throw new IdentifierConfigException(
+                    "Final map: class not found for id {$id}: {$class}"
+                );
+            }
+            if (!is_subclass_of($class, $this->baseClass)) {
+                throw new IdentifierConfigException(
+                    "Final map: {$class} must extend {$this->baseClass} (id {$id})"
+                );
+            }
+        }
+    }
+}

--- a/modules/process2/services/data/IdentifierConfigException.php
+++ b/modules/process2/services/data/IdentifierConfigException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace app\modules\process2\services\data;
+
+final class IdentifierConfigException extends \RuntimeException
+{
+}

--- a/modules/process2/services/data/IdentifierMapValidator.php
+++ b/modules/process2/services/data/IdentifierMapValidator.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace app\modules\process2\services\data;
+
+/**
+ * @template T of \app\modules\process2\components\identifier\BaseIdentifier
+ */
+interface IdentifierMapValidator
+{
+    /**
+     * @param array<int, class-string> $map
+     */
+    public function validatePreset(string $presetName, array $map): void;
+
+    /**
+     * @param array<int, class-string> $finalMap
+     */
+    public function validateFinal(array $finalMap): void;
+}


### PR DESCRIPTION
## Summary
- centralize identifier map validation via LazyFinalMapProvider and BasicIdentifierMapValidator
- publish preset without internal checks and expose module config for includes/overrides

## Testing
- `php -l modules/process2/services/data/IdentifierConfigException.php`
- `php -l modules/process2/services/data/IdentifierMapValidator.php`
- `php -l modules/process2/services/data/BasicIdentifierMapValidator.php`
- `php -l modules/process2/services/data/LazyFinalMapProvider.php`
- `php -l modules/process2/ProcessModule.php`
- `php -l modules/process2/config/web.php`


------
https://chatgpt.com/codex/tasks/task_e_68acd3ac4e58832188efd8cab5e6faad